### PR TITLE
Add `$schema` to `cgmanifest.json`

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1,64 +1,65 @@
 {
-    "Registrations":[
-        {
-            "Component": {
-                "Type": "git",
-                "git": {
-                    "RepositoryUrl": "https://github.com/EricVoll/ros-sharp",
-                    "CommitHash": "e6fb59d05f5886b774311e97cadf77b81e305bca"
-                }
-            },
-            "DevelopmentDependency" : true
-        },
-        {
-            "Component": {
-                "Type": "git",
-                "git": {
-                    "RepositoryUrl": "https://github.com/jilleJr/Newtonsoft.Json-for-Unity",
-                    "CommitHash": "bae1b836ddeff023eb204ba73c5a8649a6aa2954"
-                }
-            },
-            "DevelopmentDependency" : true
-        },
-        {
-            "Component": {
-                "Type": "git",
-                "git": {
-                    "RepositoryUrl": "https://github.com/EricVoll/RobotDynamicsLibrary",
-                    "CommitHash": "3539e028234586f0c49ae2e928be46982b2d8709"
-                }
-            },
-            "DevelopmentDependency" : true
-        },
-        {
-            "Component": {
-                "Type": "git",
-                "git": {
-                    "RepositoryUrl": "https://github.com/osrf/gazebo",
-                    "CommitHash": "10863ffa8ec28e8e0e3d3a3a588d21cdc78055ab"
-                }
-            },
-            "DevelopmentDependency" : true
-        },
-        {
-            "Component": {
-                "Type": "git",
-                "git": {
-                    "RepositoryUrl": "https://github.com/Azure/azure-spatial-anchors-samples",
-                    "CommitHash": "3c0fc627a053c2b310dfaac4d4fdc9eb533d2e04"
-                }
-            },
-            "DevelopmentDependency" : true
-        },
-        {
-            "Component": {
-                "Type": "git",
-                "git": {
-                    "RepositoryUrl": "https://github.com/microsoft/MixedRealityToolkit-Unity",
-                    "CommitHash": "bcdf1a623451c06ec2957bfbe1dd227647c9dfd4"
-                }
-            },
-            "DevelopmentDependency" : true
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "Component": {
+        "Type": "git",
+        "git": {
+          "RepositoryUrl": "https://github.com/EricVoll/ros-sharp",
+          "CommitHash": "e6fb59d05f5886b774311e97cadf77b81e305bca"
         }
-    ]
+      },
+      "DevelopmentDependency": true
+    },
+    {
+      "Component": {
+        "Type": "git",
+        "git": {
+          "RepositoryUrl": "https://github.com/jilleJr/Newtonsoft.Json-for-Unity",
+          "CommitHash": "bae1b836ddeff023eb204ba73c5a8649a6aa2954"
+        }
+      },
+      "DevelopmentDependency": true
+    },
+    {
+      "Component": {
+        "Type": "git",
+        "git": {
+          "RepositoryUrl": "https://github.com/EricVoll/RobotDynamicsLibrary",
+          "CommitHash": "3539e028234586f0c49ae2e928be46982b2d8709"
+        }
+      },
+      "DevelopmentDependency": true
+    },
+    {
+      "Component": {
+        "Type": "git",
+        "git": {
+          "RepositoryUrl": "https://github.com/osrf/gazebo",
+          "CommitHash": "10863ffa8ec28e8e0e3d3a3a588d21cdc78055ab"
+        }
+      },
+      "DevelopmentDependency": true
+    },
+    {
+      "Component": {
+        "Type": "git",
+        "git": {
+          "RepositoryUrl": "https://github.com/Azure/azure-spatial-anchors-samples",
+          "CommitHash": "3c0fc627a053c2b310dfaac4d4fdc9eb533d2e04"
+        }
+      },
+      "DevelopmentDependency": true
+    },
+    {
+      "Component": {
+        "Type": "git",
+        "git": {
+          "RepositoryUrl": "https://github.com/microsoft/MixedRealityToolkit-Unity",
+          "CommitHash": "bcdf1a623451c06ec2957bfbe1dd227647c9dfd4"
+        }
+      },
+      "DevelopmentDependency": true
+    }
+  ]
 }


### PR DESCRIPTION
This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps you to ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a build-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.
You can also use [this small script](https://github.com/JamieMagee/verify-cgmanifest) to validate your `cgmanifest.json` file.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

### Why is the diff so large?

To deserialize the `cgmanifest.json` file, we use [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
However, to serialize the JSON again we use [`prettier`](https://prettier.io/).
We found that, in general, it gave smaller diffs than the default [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.